### PR TITLE
feat: Implement minimal DXF knowledge graph import endpoint

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from backend.app.services.graph_service import GraphDatabaseService, get_graph_service
+from backend.app.models.graph_models import NodeModel, BridgeModel, ComponentModel, MaterialModel # Assuming these are defined
+import uuid
+
+router = APIRouter()
+
+@router.post("/import-dxf/{file_id}", status_code=status.HTTP_201_CREATED)
+async def import_dxf_knowledge(
+    file_id: str,
+    graph_service: GraphDatabaseService = Depends(get_graph_service)
+):
+    # Basic check for file_id (though not used yet)
+    if not file_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="file_id is required")
+
+    # Simulate reading preprocessed DXF data
+    # In a real scenario, this would come from reading and processing a file linked by file_id
+    mock_dxf_data = {
+        "bridge": {"id": f"bridge_{file_id}_{str(uuid.uuid4())[:4]}", "name": f"Bridge-{file_id}"},
+        "components": [
+            {"id": f"comp_A_{file_id}_{str(uuid.uuid4())[:4]}", "name": "Main Girder", "material_id": f"mat_steel_{file_id}"},
+            {"id": f"comp_B_{file_id}_{str(uuid.uuid4())[:4]}", "name": "Deck Slab", "material_id": f"mat_concrete_{file_id}"}
+        ],
+        "materials": [
+            {"id": f"mat_steel_{file_id}", "name": "Structural Steel"},
+            {"id": f"mat_concrete_{file_id}", "name": "Reinforced Concrete"}
+        ]
+    }
+
+    try:
+        # Create Bridge node
+        bridge_data = mock_dxf_data["bridge"]
+        bridge_node = BridgeModel(id=bridge_data["id"], name=bridge_data["name"])
+        graph_service.create_node(label="Bridge", node_data=bridge_node)
+
+        # Create Material nodes
+        for mat_data in mock_dxf_data["materials"]:
+            material_node = MaterialModel(id=mat_data["id"], name=mat_data["name"])
+            graph_service.create_node(label="Material", node_data=material_node)
+
+        # Create Component nodes
+        for comp_data in mock_dxf_data["components"]:
+            # For this PoC, we're not creating relationships yet, just the nodes.
+            # The 'material_id' in comp_data is noted but not used to link here to keep it simple.
+            component_node = ComponentModel(id=comp_data["id"], name=comp_data["name"])
+            graph_service.create_node(label="Component", node_data=component_node)
+
+        return {"status": "success", "file_id": file_id, "message": "Nodes created successfully from DXF data."}
+
+    except Exception as e:
+        # Very basic error handling for PoC
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Failed to import DXF data: {str(e)}")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,10 +69,12 @@ app.include_router(health.router, prefix=f"{settings.API_PREFIX}/health", tags=[
 from .api.endpoints import files as files_endpoint
 from .api.endpoints import preprocessing as preprocessing_endpoint
 from .api.endpoints import graph_api as graph_endpoint # 新增导入
+from .api.endpoints import knowledge as knowledge_endpoint # Import the new knowledge router
 
 app.include_router(files_endpoint.router, prefix=f"{settings.API_PREFIX}/files", tags=["Files"])
 app.include_router(preprocessing_endpoint.router, prefix=f"{settings.API_PREFIX}/preprocessing", tags=["Preprocessing"])
 app.include_router(graph_endpoint.router, prefix=f"{settings.API_PREFIX}/graph", tags=["Graph"]) # 新增图数据库API路由
+app.include_router(knowledge_endpoint.router, prefix=f"{settings.API_PREFIX}/knowledge", tags=["Knowledge"]) # Add knowledge router
 
 
 # 根路径 (可选)


### PR DESCRIPTION
- Adds a POST /api/knowledge/import-dxf/{file_id} endpoint. - Simulates reading preprocessed DXF data. - Creates Bridge, Component, 和 Material nodes in Neo4j. - Returns a simple success/failure status. - Limited to under 50 lines of code for the new endpoint logic as per PoC requirements.