### PR TITLE
feat: Complete deployment optimization with Neo4j and startup scripts

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,7 +24,10 @@ WORKDIR /app
 
 # 从构建阶段复制已安装的依赖
 COPY --from=builder /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
-COPY --from=builder /app/requirements.txt . # 复制 requirements.txt 供参考或后续操作
+# Also copy executables installed by pip
+COPY --from=builder /usr/local/bin /usr/local/bin
+# 复制 requirements.txt 供参考或后续操作
+COPY --from=builder /app/requirements.txt .
 
 # 复制应用代码
 # 注意：如果 builder 阶段已经复制了 app，这里可能需要调整

--- a/backend/app/services/dxf_parser.py
+++ b/backend/app/services/dxf_parser.py
@@ -3,7 +3,7 @@ import ezdxf
 from ezdxf.document import Drawing
 from ezdxf.entitydb import EntityDB
 from ezdxf.layouts import Modelspace
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple as TypingTuple, Union # Ensured Union is here
 from pathlib import Path
 
 # 导入rich用于调试时美化输出 (可选)
@@ -18,7 +18,7 @@ class DXFParserService:
     负责从DXF文件中提取桥梁结构信息。
     """
 
-    def __init__(self, file_path: str | Path):
+    def __init__(self, file_path: Union[str, Path]):
         """
         初始化解析服务。
 
@@ -76,7 +76,7 @@ import ezdxf
 from ezdxf.document import Drawing
 from ezdxf.entitydb import EntityDB
 from ezdxf.layouts import Modelspace
-from typing import Optional, Dict, Any, List, Tuple as TypingTuple
+from typing import Optional, Dict, Any, List, Tuple as TypingTuple, Union
 
 from pathlib import Path
 import math # 用于计算几何属性
@@ -86,7 +86,7 @@ from rich.console import Console
 from rich.table import Table
 
 # 导入数据模型
-from backend.app.models.bridge_component import BridgeComponent, ComponentType, Material, GeometryInfo
+from app.models.bridge_component import BridgeComponent, ComponentType, Material, GeometryInfo
 
 console = Console()
 
@@ -121,7 +121,7 @@ class DXFParserService:
     负责从DXF文件中提取桥梁结构信息。
     """
 
-    def __init__(self, file_path: str | Path):
+    def __init__(self, file_path: Union[str, Path]): # This is the second one
         """
         初始化解析服务。
 

--- a/start-backend.sh
+++ b/start-backend.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Script to start the backend service
+
+SUDO_PREFIX=""
+# Ensure Docker is running
+if ! docker info > /dev/null 2>&1; then
+  # Try with sudo if direct command fails
+  if ! sudo docker info > /dev/null 2>&1; then
+    echo "Error: Docker is not running or not accessible. Please start Docker and ensure you have permissions, or run this script with sudo."
+    exit 1
+  else
+    echo "INFO: Docker is accessible with sudo. Subsequent docker/compose commands will use sudo."
+    SUDO_PREFIX="sudo"
+  fi
+else
+  echo "INFO: Docker is running and accessible."
+fi
+
+# Check for .env file and create from .env.example if it doesn't exist
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    echo "INFO: .env file not found. Creating from .env.example..."
+    cp .env.example .env
+    echo "INFO: .env file created. Please review and adjust settings if necessary, especially NEO4J_PASSWORD."
+  else
+    echo "Error: .env file not found and .env.example is also missing. Cannot proceed."
+    exit 1
+  fi
+fi
+
+# Determine Docker Compose command
+BASE_COMPOSE_CMD="docker compose"
+if ! command -v docker compose &> /dev/null; then
+    if command -v docker-compose &> /dev/null; then
+        BASE_COMPOSE_CMD="docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' command found. Please install Docker Compose."
+        exit 1
+    fi
+fi
+COMPOSE_CMD="$SUDO_PREFIX $BASE_COMPOSE_CMD"
+
+echo "INFO: Using '$BASE_COMPOSE_CMD' (with sudo if needed) to manage services."
+
+# Start the backend service using Docker Compose
+echo "INFO: Starting the backend service..."
+
+# Stop backend if it's already running to ensure a clean start and apply potential .env changes
+# Check if backend service is defined and running
+# Need to ensure $COMPOSE_CMD is used here
+SERVICE_STATUS=$($COMPOSE_CMD ps -q backend 2>/dev/null)
+if [ -n "$SERVICE_STATUS" ]; then
+    echo "INFO: Backend service is already running. Stopping it first..."
+    $COMPOSE_CMD stop backend
+fi
+
+$COMPOSE_CMD up -d --no-deps --build backend # --no-deps to avoid starting neo4j if not needed, --build to pick up code changes
+
+# Check if the backend container started successfully
+# Give it a moment to start
+echo "INFO: Waiting for backend service to start (approx 15 seconds)..."
+sleep 15
+
+BACKEND_CONTAINER_ID=$($COMPOSE_CMD ps -q backend)
+if [ -z "$BACKEND_CONTAINER_ID" ]; then
+  echo "Error: Backend container failed to start. Check Docker Compose logs for details:"
+  echo "$COMPOSE_CMD logs backend"
+  exit 1
+fi
+
+# Use SUDO_PREFIX for direct docker commands too
+BACKEND_CONTAINER_STATUS=$($SUDO_PREFIX docker inspect -f '{{.State.Status}}' $BACKEND_CONTAINER_ID 2>/dev/null)
+if [ "$BACKEND_CONTAINER_STATUS" != "running" ]; then
+    echo "Error: Backend container is not running (status: $BACKEND_CONTAINER_STATUS). Check Docker Compose logs for details:"
+    echo "$COMPOSE_CMD logs backend"
+    exit 1
+fi
+
+echo "INFO: Backend container started (ID: $BACKEND_CONTAINER_ID, Status: $BACKEND_CONTAINER_STATUS)."
+
+# Health check
+BACKEND_PORT=$(grep -E '^ *ports:' docker-compose.yml -A 1 | grep -E 'backend' -A 1 | sed -n 's/.*-\s*"\([0-9]*\):.*/\1/p' | head -n 1)
+if [ -z "$BACKEND_PORT" ]; then
+    # Fallback to default from docker-compose if grep fails
+    BACKEND_PORT="8000"
+    echo "WARN: Could not dynamically determine backend port from docker-compose.yml, defaulting to $BACKEND_PORT."
+fi
+HEALTH_CHECK_URL="http://localhost:${BACKEND_PORT}/api/health"
+echo "INFO: Performing health check at $HEALTH_CHECK_URL..."
+
+# Retry mechanism for health check
+MAX_RETRIES=5
+RETRY_COUNT=0
+HEALTHY=false
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" $HEALTH_CHECK_URL)
+  if [ "$RESPONSE_CODE" = "200" ]; then
+    echo "INFO: Backend health check successful (HTTP $RESPONSE_CODE)."
+    HEALTHY=true
+    break
+  else
+    echo "INFO: Backend health check attempt $(($RETRY_COUNT + 1)) failed (HTTP $RESPONSE_CODE). Retrying in 5 seconds..."
+    RETRY_COUNT=$(($RETRY_COUNT + 1))
+    sleep 5
+  fi
+done
+
+if [ "$HEALTHY" = true ]; then
+  echo "INFO: Backend service started successfully and is healthy."
+  echo "INFO: Backend API should be available at http://localhost:${BACKEND_PORT}"
+  echo "INFO: API docs (Swagger UI) at http://localhost:${BACKEND_PORT}/docs"
+else
+  echo "Error: Backend service failed to become healthy after $MAX_RETRIES retries."
+  echo "Error: Please check the service logs: $NEEDS_SUDO $COMPOSE_CMD logs backend"
+  exit 1
+fi
+
+exit 0

--- a/start-frontend.sh
+++ b/start-frontend.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Script to start the frontend service
+
+SUDO_PREFIX=""
+# Ensure Docker is running
+if ! docker info > /dev/null 2>&1; then
+  if ! sudo docker info > /dev/null 2>&1; then
+    echo "Error: Docker is not running or not accessible. Please start Docker and ensure you have permissions, or run this script with sudo."
+    exit 1
+  else
+    echo "INFO: Docker is accessible with sudo. Subsequent docker/compose commands will use sudo."
+    SUDO_PREFIX="sudo"
+  fi
+else
+  echo "INFO: Docker is running and accessible."
+fi
+
+# Check for .env file (less critical for frontend but good for consistency)
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    echo "INFO: .env file not found. Creating from .env.example..."
+    cp .env.example .env
+    echo "INFO: .env file created."
+  else
+    # Not exiting as .env might be less critical for frontend directly
+    echo "Warning: .env file not found and .env.example is also missing."
+  fi
+fi
+
+# Determine Docker Compose command
+BASE_COMPOSE_CMD="docker compose"
+if ! command -v docker compose &> /dev/null; then
+    if command -v docker-compose &> /dev/null; then
+        BASE_COMPOSE_CMD="docker-compose"
+    else
+        echo "Error: Neither 'docker compose' nor 'docker-compose' command found. Please install Docker Compose."
+        exit 1
+    fi
+fi
+COMPOSE_CMD="$SUDO_PREFIX $BASE_COMPOSE_CMD"
+
+echo "INFO: Using '$BASE_COMPOSE_CMD' (with sudo if needed) to manage services."
+
+# Optional: Run npm install in frontend directory if node_modules is missing
+# This ensures that if the Dockerfile.dev relies on host node_modules, they are present.
+# The frontend/Dockerfile.dev likely runs `npm install` itself, so this might be redundant
+# but can be helpful for local consistency or specific Dockerfile.dev setups.
+if [ -d "frontend" ] && [ ! -d "frontend/node_modules" ]; then
+  echo "INFO: frontend/node_modules not found. Running npm install in ./frontend..."
+  (cd frontend && npm install)
+  if [ $? -ne 0 ]; then
+    echo "Error: npm install in ./frontend failed. Please check for errors."
+    # exit 1 # Decide if this should be a fatal error
+  fi
+elif [ ! -d "frontend" ]; then
+    echo "Warning: ./frontend directory not found, skipping npm install check."
+fi
+
+
+# Start the frontend service using Docker Compose
+echo "INFO: Starting the frontend service..."
+
+SERVICE_STATUS=$($COMPOSE_CMD ps -q frontend 2>/dev/null)
+if [ -n "$SERVICE_STATUS" ]; then
+    echo "INFO: Frontend service is already running. Stopping it first..."
+    $COMPOSE_CMD stop frontend
+fi
+
+$COMPOSE_CMD up -d --no-deps --build frontend
+
+# Check if the frontend container started successfully
+echo "INFO: Waiting for frontend service to start (approx 10-15 seconds)..."
+sleep 15 # Vite can be quick for dev server
+
+FRONTEND_CONTAINER_ID=$($COMPOSE_CMD ps -q frontend)
+if [ -z "$FRONTEND_CONTAINER_ID" ]; then
+  echo "Error: Frontend container failed to start. Check Docker Compose logs for details:"
+  echo "$COMPOSE_CMD logs frontend"
+  exit 1
+fi
+
+FRONTEND_CONTAINER_STATUS=$($SUDO_PREFIX docker inspect -f '{{.State.Status}}' $FRONTEND_CONTAINER_ID 2>/dev/null)
+if [ "$FRONTEND_CONTAINER_STATUS" != "running" ]; then
+    echo "Error: Frontend container is not running (status: $FRONTEND_CONTAINER_STATUS). Check Docker Compose logs for details:"
+    echo "$COMPOSE_CMD logs frontend"
+    exit 1
+fi
+echo "INFO: Frontend container started (ID: $FRONTEND_CONTAINER_ID, Status: $FRONTEND_CONTAINER_STATUS)."
+
+# Health check for frontend (simple HTTP check)
+# Extract frontend port from docker-compose.yml
+# This regex is a bit fragile; assumes "XXXX:YYYY" format and takes the host port (XXXX)
+FRONTEND_PORT=$(grep -E '^ *ports:' docker-compose.yml -A 2 | grep -A 1 'frontend:' | sed -n 's/.*-\s*"\([0-9]*\):.*/\1/p' | head -n 1)
+
+if [ -z "$FRONTEND_PORT" ]; then
+    FRONTEND_PORT="3000" # Default from docker-compose.yml
+    echo "WARN: Could not dynamically determine frontend port from docker-compose.yml, defaulting to $FRONTEND_PORT."
+fi
+HEALTH_CHECK_URL="http://localhost:${FRONTEND_PORT}"
+echo "INFO: Performing health check by trying to reach $HEALTH_CHECK_URL..."
+
+MAX_RETRIES=3
+RETRY_COUNT=0
+HEALTHY=false
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  # Using curl -I to get headers, or -L to follow redirects if any, -s for silent, -o /dev/null to discard body
+  # Checking for any 2xx or 3xx HTTP code as success for a basic frontend check
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -L --max-time 5 $HEALTH_CHECK_URL)
+  if [[ "$RESPONSE_CODE" =~ ^[23]..$ ]]; then # Check for 2xx or 3xx response codes
+    echo "INFO: Frontend health check successful (HTTP $RESPONSE_CODE)."
+    HEALTHY=true
+    break
+  else
+    echo "INFO: Frontend health check attempt $(($RETRY_COUNT + 1)) failed (HTTP $RESPONSE_CODE). Retrying in 5 seconds..."
+    RETRY_COUNT=$(($RETRY_COUNT + 1))
+    sleep 5
+  fi
+done
+
+if [ "$HEALTHY" = true ]; then
+  echo "INFO: Frontend service started successfully and is reachable."
+  echo "INFO: Frontend should be available at $HEALTH_CHECK_URL"
+else
+  echo "Error: Frontend service failed to become healthy after $MAX_RETRIES retries (last HTTP code: $RESPONSE_CODE)."
+  echo "Error: Please check the service logs: $COMPOSE_CMD logs frontend"
+  echo "Error: Also ensure the backend service is running if the frontend depends on it for its main page content."
+  exit 1 # Making this a fatal error for the script
+fi
+
+exit 0


### PR DESCRIPTION
This commit introduces startup scripts and includes fixes to ensure service startup for the MVP environment. Deployment documentation is included below.

Key changes:
- Created `start-backend.sh` to manage the backend service startup, including Docker/sudo checks, .env handling, and health checks.
- Created `start-frontend.sh` with similar functionality for the frontend service.
- Corrected issues in `backend/Dockerfile` related to COPY instructions and ensuring `uvicorn` is in PATH for the production stage.
- Fixed Python import and type hint errors in `backend/app/services/dxf_parser.py` for compatibility with Python 3.9.
- Neo4j configuration within `docker-compose.yml` was reviewed and deemed suitable.

Note: Full testing of scripts and application stability was impeded by recurring "out of disk space" environment errors. Some manual verification of Neo4j startup and script permissions was performed.

## Simplified Deployment Instructions:

### Prerequisites:
1.  Docker & Docker Compose installed and running.
2.  Project repository cloned.

### Environment Configuration:
1.  Copy `.env.example` to `.env` in the project root: `cp .env.example .env`
2.  Review/modify `NEO4J_PASSWORD` in `.env` if desired (defaults to `s3cr3t`).

### To Start All Services (Neo4j, Backend, Frontend):
```bash
# If Docker requires sudo:
sudo docker compose up --build -d

# Otherwise:
docker compose up --build -d
```

### To Start Individual Services:
(Ensure Docker is running, scripts attempt sudo if needed)

1.  **Neo4j:** ```bash # Ensure .env has NEO4J_USER/PASSWORD set as expected by docker-compose.yml sudo docker compose up -d neo4j ``` Access Neo4j Browser: `http://localhost:7474`

2.  **Backend (after Neo4j is running):** ```bash ./start-backend.sh ``` API Docs: `http://localhost:8000/docs`

3.  **Frontend (after backend is running):** ```bash ./start-frontend.sh ``` App URL: `http://localhost:3000`

### To Stop All Services:
```bash
# If Docker requires sudo:
sudo docker compose down

# Otherwise:
docker compose down
```
To also remove Neo4j data: `sudo docker compose down -v` (use with caution).

### View Logs:
`sudo docker compose logs <service_name>` (e.g., `backend`, `frontend`, `neo4j`) `sudo docker compose logs -f <service_name>` (to follow logs)