### PR TITLE
feat: Integrate local LLM service infrastructure

### DIFF
--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, HTTPException, Body
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any
+
+from backend.app.services.ai_service import get_ollama_chat_response, OllamaError
+from backend.app.core.config import settings # For default model if specified
+
+router = APIRouter()
+
+# --- Pydantic Models ---
+class AIChatRequest(BaseModel):
+    message: str = Field(..., description="The user's message to the AI.")
+    context: Optional[str] = Field(None, description="Optional context to provide to the AI.")
+    model: Optional[str] = Field(None, description="Optional Ollama model to use (e.g., 'qwen2.5:7b'). Uses system default if not provided.")
+    # stream: bool = Field(False, description="Whether to stream the response.") # Streaming not implemented yet
+
+class AIChatResponse(BaseModel):
+    role: str = Field(description="The role of the responder (e.g., 'assistant').")
+    content: str = Field(description="The AI's response content.")
+    model_used: str = Field(description="The Ollama model that generated the response.")
+    # additional_info: Optional[Dict[str, Any]] = Field(None, description="Additional information from the Ollama response if any.")
+
+
+@router.post("/chat", response_model=AIChatResponse)
+async def handle_ai_chat(
+    request: AIChatRequest = Body(...)
+):
+    """
+    Receives a user message and optional context, communicates with the
+    Ollama service, and returns the AI's response.
+    """
+    try:
+        selected_model = request.model or getattr(settings, 'OLLAMA_DEFAULT_MODEL', "qwen2:0.5b") # Fallback if not in settings
+
+        ollama_response = await get_ollama_chat_response(
+            message=request.message,
+            context=request.context,
+            model=selected_model
+        )
+
+        # Extract the relevant part of the response
+        # Based on current ai_service.py, response is like:
+        # {
+        #   "model": "qwen2:0.5b",
+        #   "created_at": "...",
+        #   "message": { "role": "assistant", "content": "..." },
+        #   "done": true,
+        #   ... (other stats)
+        # }
+
+        if not ollama_response or "message" not in ollama_response:
+            raise HTTPException(status_code=500, detail="Invalid response structure from AI service.")
+
+        ai_message = ollama_response.get("message", {})
+        response_content = ai_message.get("content", "")
+        response_role = ai_message.get("role", "assistant")
+        model_used = ollama_response.get("model", selected_model)
+
+
+        return AIChatResponse(
+            role=response_role,
+            content=response_content,
+            model_used=model_used
+            # additional_info={k: v for k, v in ollama_response.items() if k not in ["message", "model"]}
+        )
+
+    except OllamaError as e:
+        # Log the error e.message or str(e)
+        print(f"Ollama service error: {e}") # Replace with actual logging
+        detail = f"Error communicating with AI service: {str(e)}"
+        if e.status_code:
+            if e.status_code == 404: # Model not found
+                 detail = f"AI model '{request.model or selected_model}' not found on Ollama server. Ensure it's pulled. Error: {str(e)}"
+            elif e.status_code == 503: # Service unavailable
+                 detail = f"AI service (Ollama) is unavailable. Ensure it's running. Error: {str(e)}"
+        raise HTTPException(status_code=e.status_code or 503, detail=detail)
+    except HTTPException:
+        # Re-raise HTTPException if it was raised intentionally
+        raise
+    except Exception as e:
+        # Log the error
+        print(f"Unexpected error in AI chat endpoint: {e}") # Replace with actual logging
+        raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+
+# Example of how to add this router to your main app:
+# from backend.app.api.v1.endpoints import ai as ai_router
+# app.include_router(ai_router.router, prefix="/api/v1/ai", tags=["AI Service"])

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     # 日志级别
     LOG_LEVEL: str = "INFO"
 
+    # Ollama Configuration
+    OLLAMA_API_URL: AnyHttpUrl = "http://localhost:11434/api/chat" # Default Ollama API URL
+    OLLAMA_DEFAULT_MODEL: str = "qwen2:0.5b" # Default model to use if not specified in request
+
     class Config:
         case_sensitive = True # 环境变量名大小写敏感
         env_file = ".env" # 指定 .env 文件名 (虽然我们已经手动加载了)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -70,11 +70,13 @@ from .api.endpoints import files as files_endpoint
 from .api.endpoints import preprocessing as preprocessing_endpoint
 # from .api.endpoints import graph_api as graph_endpoint # 新增导入 - 已移除，由 knowledge_endpoint 替代
 from .api.endpoints import knowledge as knowledge_endpoint # Import the new knowledge router
+from .api.v1.endpoints import ai as ai_endpoint # Import the new AI router
 
 app.include_router(files_endpoint.router, prefix=f"{settings.API_PREFIX}/files", tags=["Files"])
 app.include_router(preprocessing_endpoint.router, prefix=f"{settings.API_PREFIX}/preprocessing", tags=["Preprocessing"])
 # app.include_router(graph_endpoint.router, prefix=f"{settings.API_PREFIX}/graph", tags=["Graph"]) # 新增图数据库API路由 - 已移除
 app.include_router(knowledge_endpoint.router, prefix=f"{settings.API_PREFIX}/knowledge", tags=["Knowledge"]) # Add knowledge router
+app.include_router(ai_endpoint.router, prefix=f"{settings.API_PREFIX}/v1/ai", tags=["AI Service"]) # Add AI router with /v1
 
 
 # 根路径 (可选)

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,0 +1,127 @@
+import httpx # Changed from requests to httpx for async
+import json
+from typing import Optional, Dict, Any
+
+from backend.app.core.config import settings # Assuming settings will hold OLLAMA_API_URL
+
+# Default Ollama API URL if not specified in settings
+DEFAULT_OLLAMA_API_URL = "http://localhost:11434/api/chat"
+DEFAULT_MODEL = "qwen2:0.5b" # Using a smaller model for initial testing
+
+class OllamaError(Exception):
+    """Custom exception for Ollama API errors."""
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+async def get_ollama_chat_response(
+    message: str,
+    context: Optional[str] = None,
+    model: Optional[str] = None,
+    ollama_api_url: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Sends a message to the Ollama API and returns the chat response.
+
+    Args:
+        message: The user's message.
+        context: Optional context to provide to the LLM.
+        model: The Ollama model to use (e.g., "qwen2.5:7b", "llama3.1:8b").
+               Defaults to DEFAULT_MODEL.
+        ollama_api_url: The URL of the Ollama API. Defaults to OLLAMA_API_URL from settings
+                        or DEFAULT_OLLAMA_API_URL.
+
+    Returns:
+        A dictionary containing the Ollama API response.
+
+    Raises:
+        OllamaError: If the API request fails or returns an error.
+    """
+    api_url = ollama_api_url or getattr(settings, 'OLLAMA_API_URL', DEFAULT_OLLAMA_API_URL)
+    selected_model = model or getattr(settings, 'OLLAMA_DEFAULT_MODEL', DEFAULT_MODEL)
+
+    system_prompt = "You are a helpful assistant."
+    if context:
+        # Basic context integration. This can be refined.
+        user_message_content = f"Context: {context}\n\nUser Question: {message}"
+    else:
+        user_message_content = message
+
+    payload = {
+        "model": selected_model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message_content}
+        ],
+        "stream": False  # For now, we'll use non-streaming responses
+    }
+
+    async with httpx.AsyncClient(timeout=60.0) as client: # Increased timeout
+        try:
+            response = await client.post(api_url, json=payload)
+            response.raise_for_status()  # Raises HTTPStatusError for 4xx/5xx responses
+
+            # The response from Ollama is a stream of JSON objects, even for stream=False.
+            # We need to parse them line by line if it's not a single JSON object.
+            # However, with stream=False, it should be a single JSON object.
+            response_data = response.json()
+
+            # Ensure the response structure is as expected
+            if "message" not in response_data or "content" not in response_data["message"]:
+                raise OllamaError(f"Unexpected response structure from Ollama: {response_data}")
+
+            return response_data
+
+        except httpx.HTTPStatusError as e:
+            error_message = f"Ollama API request failed with status {e.response.status_code}: {e.response.text}"
+            print(f"Error: {error_message}") # For logging
+            raise OllamaError(error_message, status_code=e.response.status_code) from e
+        except httpx.RequestError as e:
+            error_message = f"Error connecting to Ollama API at {api_url}: {e}"
+            print(f"Error: {error_message}") # For logging
+            raise OllamaError(error_message) from e
+        except json.JSONDecodeError as e:
+            error_message = f"Failed to decode JSON response from Ollama: {e}. Response text: {response.text if 'response' in locals() else 'N/A'}"
+            print(f"Error: {error_message}") # For logging
+            raise OllamaError(error_message) from e
+
+if __name__ == '__main__':
+    import asyncio
+
+    async def main():
+        print(f"Testing Ollama connection to: {getattr(settings, 'OLLAMA_API_URL', DEFAULT_OLLAMA_API_URL)}")
+        print(f"Using model: {getattr(settings, 'OLLAMA_DEFAULT_MODEL', DEFAULT_MODEL)}")
+
+        # Make sure Ollama server is running and the model is pulled:
+        # ollama pull qwen2:0.5b
+
+        try:
+            # Test without context
+            print("\n--- Test 1: Without context ---")
+            response_no_context = await get_ollama_chat_response(message="Hello, who are you?")
+            print("Ollama Response (no context):")
+            # print(json.dumps(response_no_context, indent=2))
+            print(f"  Role: {response_no_context.get('message', {}).get('role')}")
+            print(f"  Content: {response_no_context.get('message', {}).get('content')}")
+
+
+            # Test with context
+            print("\n--- Test 2: With context ---")
+            sample_context = "The bridge is a suspension bridge built in 1967. It has shown signs of corrosion on the main cables."
+            response_with_context = await get_ollama_chat_response(
+                message="What are the main concerns for this structure?",
+                context=sample_context
+            )
+            print("Ollama Response (with context):")
+            # print(json.dumps(response_with_context, indent=2))
+            print(f"  Role: {response_with_context.get('message', {}).get('role')}")
+            print(f"  Content: {response_with_context.get('message', {}).get('content')}")
+
+        except OllamaError as e:
+            print(f"An error occurred: {e}")
+            if e.status_code:
+                print(f"Status Code: {e.status_code}")
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+
+    asyncio.run(main())


### PR DESCRIPTION
- Create AI service module (ai_service.py) for Ollama client connection.
- Implement HTTP API call to Ollama's /api/chat.
- Add /api/v1/ai/chat endpoint with request/response models.
- Include basic error handling and configuration for Ollama URL and model.
- Prepare foundation for knowledge graph integration in AI Q&A.