### PR TITLE
Fix: Create .env file and remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   frontend:
     # 开发环境配置:


### PR DESCRIPTION
- Created .env file in the root directory by copying .env.example to resolve the 'env file not found' error.
- Removed the 'version' attribute from docker-compose.yml to address the obsolescence warning.