### PR TITLE
Refactor: Use relative imports to fix ModuleNotFoundError in Docker

### DIFF
--- a/backend/app/api/endpoints/files.py
+++ b/backend/app/api/endpoints/files.py
@@ -4,8 +4,8 @@ from typing import Dict, Any, Optional
 import shutil # 用于文件操作
 from pathlib import Path
 
-from backend.app.services.dxf_parser import DXFParserService
-from backend.app.models.bridge_component import BridgeComponent # 虽然API直接返回dict，但类型提示可能有用
+from ...services.dxf_parser import DXFParserService
+from ...models.bridge_component import BridgeComponent # 虽然API直接返回dict，但类型提示可能有用
 
 router = APIRouter()
 

--- a/backend/app/api/endpoints/graph_api.py
+++ b/backend/app/api/endpoints/graph_api.py
@@ -4,14 +4,14 @@ from typing import List, Dict, Any, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Body, Path, Query
 
-from backend.app.models.graph_models import (
+from ...models.graph_models import (
     NodeModel, # Base for type hinting
     BridgeModel, ComponentModel, MaterialModel, StandardModel,
     BridgeCreateSchema, ComponentCreateSchema, MaterialCreateSchema, StandardCreateSchema,
     BridgeUpdateSchema, ComponentUpdateSchema, MaterialUpdateSchema, StandardUpdateSchema,
     RelationshipData, NodeResponse, RelationshipResponse
 )
-from backend.app.services.graph_service import GraphDatabaseService, get_graph_service
+from ...services.graph_service import GraphDatabaseService, get_graph_service
 from neo4j import Driver
 # It's better to get the service via DI rather than driver directly in endpoint
 # from backend.app.db.neo4j_driver import get_db_session # For direct session use if needed

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from backend.app.services.graph_service import GraphDatabaseService, get_graph_service
-from backend.app.models.graph_models import NodeModel, BridgeModel, ComponentModel, MaterialModel # Assuming these are defined
+from ...services.graph_service import GraphDatabaseService, get_graph_service
+from ...models.graph_models import NodeModel, BridgeModel, ComponentModel, MaterialModel # Assuming these are defined
 import uuid
 
 router = APIRouter()

--- a/backend/app/api/endpoints/preprocessing.py
+++ b/backend/app/api/endpoints/preprocessing.py
@@ -4,10 +4,10 @@ from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, UploadFi
 from typing import Dict, Any, Optional
 from pathlib import Path
 
-from backend.app.services.file_service import FileService
-from backend.app.services.dxf_parser import DXFParserService
-from backend.app.services.data_preprocessor import DataPreprocessorService
-from backend.app.core.config import settings # 用于获取上传目录等配置
+from ...services.file_service import FileService
+from ...services.dxf_parser import DXFParserService
+from ...services.data_preprocessor import DataPreprocessorService
+from ...core.config import settings # 用于获取上传目录等配置
 
 router = APIRouter()
 

--- a/backend/app/api/v1/endpoints/ai.py
+++ b/backend/app/api/v1/endpoints/ai.py
@@ -2,8 +2,8 @@ from fastapi import APIRouter, HTTPException, Body
 from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any
 
-from backend.app.services.ai_service import get_ollama_chat_response, OllamaError
-from backend.app.core.config import settings # For default model if specified
+from .....services.ai_service import get_ollama_chat_response, OllamaError
+from .....core.config import settings # For default model if specified
 
 router = APIRouter()
 

--- a/backend/app/db/neo4j_driver.py
+++ b/backend/app/db/neo4j_driver.py
@@ -1,7 +1,7 @@
 # backend/app/db/neo4j_driver.py
 from neo4j import GraphDatabase, Driver
 from neo4j.exceptions import Neo4jError # Corrected import for Neo4jError
-from backend.app.core.config import settings
+from ..core.config import settings
 import logging
 
 logger = logging.getLogger(__name__)

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -2,7 +2,7 @@ import httpx # Changed from requests to httpx for async
 import json
 from typing import Optional, Dict, Any
 
-from backend.app.core.config import settings # Assuming settings will hold OLLAMA_API_URL
+from ..core.config import settings # Assuming settings will hold OLLAMA_API_URL
 
 # Default Ollama API URL if not specified in settings
 DEFAULT_OLLAMA_API_URL = "http://localhost:11434/api/chat"

--- a/backend/app/services/graph_service.py
+++ b/backend/app/services/graph_service.py
@@ -3,11 +3,11 @@ import logging
 from typing import List, Dict, Any, Optional
 from neo4j import Driver, Session, Transaction, Record
 from neo4j.exceptions import Neo4jError # Corrected import for Neo4jError
-from backend.app.models.graph_models import (
+from ..models.graph_models import (
     NodeModel, BridgeModel, ComponentModel, MaterialModel, StandardModel,
     RelationshipData, NodeResponse # Assuming NodeResponse might be useful
 )
-from backend.app.core.config import settings
+from ..core.config import settings
 import uuid
 
 logger = logging.getLogger(__name__)
@@ -807,7 +807,7 @@ def get_graph_service() -> GraphDatabaseService:
     # by setting _graph_db_service_instance to None before calling.
     if _graph_db_service_instance is None:
         # Import here to avoid circular dependencies if models are imported at top level by neo4j_driver
-        from backend.app.db.neo4j_driver import get_neo4j_driver
+        from ..db.neo4j_driver import get_neo4j_driver
         try:
             actual_driver = get_neo4j_driver()
         except ConnectionError as e:

--- a/backend/app/tests/api/test_graph_api.py
+++ b/backend/app/tests/api/test_graph_api.py
@@ -6,9 +6,9 @@ import uuid
 
 # Assuming your FastAPI app instance is accessible for testing
 # If main.py defines `app`, and tests are run from project root, this might work:
-from backend.app.main import app  # Main FastAPI app instance
-from backend.app.core.config import settings
-from backend.app.services.graph_service import GraphDatabaseService, get_graph_service
+from ...main import app  # Main FastAPI app instance
+from ...core.config import settings
+from ...services.graph_service import GraphDatabaseService, get_graph_service
 
 # Test data IDs
 API_TEST_BRIDGE_ID = f"api-test-bridge-{uuid.uuid4()}"
@@ -99,7 +99,7 @@ async def test_api_get_all_bridges(async_client: AsyncClient):
 
     # Use the service to create directly to simplify test setup for GET all
     service = get_graph_service()
-    from backend.app.models.graph_models import BridgeModel
+    from ...models.graph_models import BridgeModel
     service.create_node("Bridge", BridgeModel(id=temp_bridge_id, name="Bridge for GET ALL test"))
 
     response = await async_client.get("/graph/nodes/Bridge?limit=5")
@@ -120,7 +120,7 @@ async def test_api_update_bridge(async_client: AsyncClient):
     cleanup_test_node_via_service("Bridge", bridge_to_update_id)
 
     service = get_graph_service()
-    from backend.app.models.graph_models import BridgeModel, BridgeCreateSchema
+    from ...models.graph_models import BridgeModel, BridgeCreateSchema
     # Create using schema, then construct full model for service
     create_schema = BridgeCreateSchema(name="Bridge to Update Original", location="Original Location")
     full_model = BridgeModel(**create_schema.dict(), id=bridge_to_update_id) # Pydantic V1
@@ -151,7 +151,7 @@ async def test_api_delete_bridge(async_client: AsyncClient):
     cleanup_test_node_via_service("Bridge", bridge_to_delete_id)
 
     service = get_graph_service()
-    from backend.app.models.graph_models import BridgeModel, BridgeCreateSchema
+    from ...models.graph_models import BridgeModel, BridgeCreateSchema
     create_schema = BridgeCreateSchema(name="Bridge to Delete")
     full_model = BridgeModel(**create_schema.dict(), id=bridge_to_delete_id)
     service.create_node("Bridge", full_model)
@@ -181,7 +181,7 @@ async def test_api_create_relationship(async_client: AsyncClient):
     cleanup_test_node_via_service("Component", c_id_rel)
 
     service = get_graph_service()
-    from backend.app.models.graph_models import BridgeModel, ComponentModel
+    from ...models.graph_models import BridgeModel, ComponentModel
     service.create_node("Bridge", BridgeModel(id=b_id_rel, name="Rel Test Bridge"))
     service.create_node("Component", ComponentModel(id=c_id_rel, name="Rel Test Component"))
 
@@ -262,7 +262,7 @@ async def test_api_custom_read_query(async_client: AsyncClient):
     mat_id_query = f"api-query-mat-{uuid.uuid4()}"
     cleanup_test_node_via_service("Material", mat_id_query)
     service = get_graph_service()
-    from backend.app.models.graph_models import MaterialModel
+    from ...models.graph_models import MaterialModel
     service.create_node("Material", MaterialModel(id=mat_id_query, name="Query Test Material", material_type="Steel"))
 
     query_payload = {
@@ -320,7 +320,7 @@ async def test_api_get_bridge_components(async_client: AsyncClient):
     cleanup_test_node_via_service("Component", c2_id_complex)
 
     service = get_graph_service()
-    from backend.app.models.graph_models import BridgeModel, ComponentModel, RelationshipData
+    from ...models.graph_models import BridgeModel, ComponentModel, RelationshipData
     service.create_node("Bridge", BridgeModel(id=b_id_complex, name="Complex Query Bridge"))
     service.create_node("Component", ComponentModel(id=c1_id_complex, name="Complex Comp 1"))
     service.create_node("Component", ComponentModel(id=c2_id_complex, name="Complex Comp 2"))

--- a/backend/app/tests/api/test_knowledge_api.py
+++ b/backend/app/tests/api/test_knowledge_api.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.testclient import TestClient
-from backend.app.main import app # 确保从正确的位置导入 app
-from backend.app.core.config import settings
+from ...main import app # 确保从正确的位置导入 app
+from ...core.config import settings
 
 client = TestClient(app)
 

--- a/backend/app/tests/services/test_data_preprocessor.py
+++ b/backend/app/tests/services/test_data_preprocessor.py
@@ -3,7 +3,7 @@ import pytest
 import copy # For deep copying mock data
 from pathlib import Path
 
-from backend.app.services.data_preprocessor import DataPreprocessorService
+from ...services.data_preprocessor import DataPreprocessorService
 # from backend.app.models.bridge_component import ComponentType # 如果需要比较枚举
 
 # --- Mock Data Fixtures ---

--- a/backend/app/tests/services/test_dxf_parser.py
+++ b/backend/app/tests/services/test_dxf_parser.py
@@ -1,7 +1,7 @@
 # backend/app/tests/services/test_dxf_parser.py
 import unittest
 from pathlib import Path
-from backend.app.services.dxf_parser import DXFParserService, ComponentType, Material
+from ...services.dxf_parser import DXFParserService, ComponentType, Material
 
 # 测试数据所在的目录
 TEST_DATA_DIR = Path(__file__).parent.parent / "test_data"
@@ -17,13 +17,16 @@ if not TEST_DXF_FILE.exists():
         print(f"Test DXF file was missing, created it at: {TEST_DXF_FILE}")
     except ImportError:
         # 如果create_test_dxf不在同一目录，尝试从services目录导入
-        try:
-            from backend.app.tests.services.create_test_dxf import create_sample_dxf_for_testing
-            create_sample_dxf_for_testing(TEST_DXF_FILE)
-            print(f"Test DXF file was missing, created it at: {TEST_DXF_FILE}")
-        except ImportError:
-            raise FileNotFoundError(
-                f"Test DXF file '{TEST_DXF_FILE}' not found and could not be auto-generated. "
+        # This fallback is likely redundant if the primary relative import '.create_test_dxf' is correct.
+        # However, to fulfill the request of changing all 'backend.app...' paths, this specific one will be removed.
+        # If '.create_test_dxf' fails, the error will propagate.
+        # try:
+        #     from backend.app.tests.services.create_test_dxf import create_sample_dxf_for_testing
+        #     create_sample_dxf_for_testing(TEST_DXF_FILE)
+        #     print(f"Test DXF file was missing, created it at: {TEST_DXF_FILE}")
+        # except ImportError:
+        raise FileNotFoundError(
+            f"Test DXF file '{TEST_DXF_FILE}' not found and could not be auto-generated. "
                 "Please run create_test_dxf.py first."
             )
     if not TEST_DXF_FILE.exists(): # 再次检查

--- a/backend/app/tests/services/test_graph_service.py
+++ b/backend/app/tests/services/test_graph_service.py
@@ -3,13 +3,13 @@ import pytest
 from neo4j import Driver
 import uuid
 
-from backend.app.services.graph_service import GraphDatabaseService, get_graph_service
-from backend.app.db.neo4j_driver import get_neo4j_driver, close_neo4j_driver
-from backend.app.models.graph_models import (
+from ...services.graph_service import GraphDatabaseService, get_graph_service
+from ...db.neo4j_driver import get_neo4j_driver, close_neo4j_driver
+from ...models.graph_models import (
     BridgeModel, ComponentModel, MaterialModel, StandardModel,
     RelationshipData
 )
-from backend.app.core.config import settings
+from ...core.config import settings
 
 # 全局测试数据
 TEST_BRIDGE_ID = f"test-bridge-{uuid.uuid4()}"


### PR DESCRIPTION
Changed all absolute imports starting with 'from backend.app...' to relative imports (e.g., 'from ..core...') within the backend/app directory.

This addresses the 'ModuleNotFoundError: No module named backend' that occurred when running the application inside a Docker container where 'backend/app' is the top-level package context.